### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,6 +101,7 @@ jobs:
         if: runner.os == 'macOS' && matrix.config.r != 'devel'
         run: |
           brew install ccache
+          brew cask install xquartz
           wget https://cran.r-project.org/bin/macosx/tools/clang-7.0.0.pkg
           sudo installer -package clang-7.0.0.pkg -target /
           mkdir -p ~/.R && echo -e 'CXX_STD = CXX14\n\nCC=ccache /usr/local/clang7/bin/clang\nCC11=ccache /usr/local/clang7/bin/clang\nCC14=ccache /usr/local/clang7/bin/clang\nCXX=ccache /usr/local/clang7/bin/clang++\nCXX11=ccache /usr/local/clang7/bin/clang++\nCXX14=ccache /usr/local/clang7/bin/clang++\nC11=ccache /usr/local/clang7/bin/clang++\nC14=ccache /usr/local/clang7/bin/clang++\nF77=ccache gfortran/nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCXXFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk\nCFLAGS=-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' > $HOME/.R/Makevars
@@ -111,6 +112,7 @@ jobs:
         if: runner.os == 'macOS' && matrix.config.r == 'devel'
         run: |
           brew install ccache
+          brew cask install xquartz
           # install SDK 10.13 (High Sierra, used by CRAN)
           wget -nv https://github.com/phracker/MacOSX-SDKs/releases/download/10.15/MacOSX10.13.sdk.tar.xz
           tar fxz MacOSX10.13.sdk.tar.xz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,8 +77,8 @@ jobs:
         uses: pat-s/always-upload-cache@v1.1.4
         with:
           path: ${{ env.R_LIBS_USER }}
-          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
-          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}
+          key: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}-1
+          restore-keys: ${{ runner.os }}-r-${{ matrix.config.r }}-${{steps.date.outputs.date}}-1
 
       - name: "[Cache] Cache ccache"
         if: runner.os != 'Windows'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Suggests:
     sm,
     testthat
 Remotes:
-    mlr-org/mlr3proba
+    mlr-org/mlr3proba,
     mlr-org/mlr3
 Encoding: UTF-8
 NeedsCompilation: no

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Suggests:
     testthat
 Remotes:
     mlr-org/mlr3proba
+    mlr-org/mlr3
 Encoding: UTF-8
 NeedsCompilation: no
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
The problem was that XQuartz was missing on macOS (i.e. X11).

In addition an unresolvable conflict exists if mlr3proba dev is requested since it required mlr3dev (?) but mlr3 cran will be installed earlier and then the dev install errors as mlr3 is already loaded.

Therefore I had to include mlr3dev in the Remotes section in DESCRIPTION (and had to bump the cache versioning to start fresh). You can remove both once mlr3proba got updated on CRAN.

Also I suggest looking at the logs in more detail next time to figure out the actual install error of a package :)